### PR TITLE
Fix: 커뮤니티 목록 무한스크롤 로딩 상태 및 중복 요청 처리 개선

### DIFF
--- a/src/api/server/community.ts
+++ b/src/api/server/community.ts
@@ -11,7 +11,8 @@ import { getCommunitiesMock } from "../mock/community";
 
 //무한스크롤 전용 목업 데이터 테스트용
 // const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
-const USE_MOCK = "true";
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true" //:::테스트 끝나고 false로 돌리기!!!!!!!!!!!!!!!
+
 
 export const getCommunities = async (
   category: string = "none",
@@ -24,10 +25,6 @@ export const getCommunities = async (
     return getCommunitiesMock(category, page);
   }
 
-export const getCommunities = async (
-  category: string = "none",
-  page: string = "0"
-) => {
   try {
     const url = `https://api.dive-in.co.kr/community/posts/list/${category}/${page}`;
     const response = await fetch(url);
@@ -51,6 +48,7 @@ export const getCommunities = async (
     return { posts: [], totalPosts: 0, hasMore: false }; //아 여기 반환값 달라서 에러났던 거였음? 하...참나
   }
 };
+
 
 // export const getCommunity = async (postId: string): Promise<CommunityProps | null> => {
 export const getCommunity = async (postId: string) => {

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -6,7 +6,11 @@ import FloatingButton from "../../_components/FloatingButton";
 import CategoryFilter from "@/app/community/_components/CategoryFilter";
 import { getCommunities } from "@/api/server/community";
 import { useRouter } from "next/navigation";
-import { CommunitiesProps, communityResponseDetailProps, communityResponseProps } from "@/types/community";
+import {
+  CommunitiesProps,
+  communityResponseDetailProps,
+  communityResponseProps,
+} from "@/types/community";
 import { CATEGORIES } from "@/constants/categories";
 import { useInView } from "react-intersection-observer";
 
@@ -19,60 +23,92 @@ import { useInView } from "react-intersection-observer";
 //   {name: "수영대회", key: "competition"},
 // ];
 
-export default function CommunitiesClient({ communityList, category, page }:{
+type Status = "idle" | "loading" | "success" | "error";
+
+export default function CommunitiesClient({
+  communityList,
+  category,
+  page,
+}: {
   // communityList: CommunitiesProps[];
-    communityList: communityResponseDetailProps;
-    category: string; 
-    page: string;
-    // hasMore: boolean;
-    // totalposts: number;
-  }) {
+  communityList: communityResponseDetailProps;
+  category: string;
+  page: string;
+  // hasMore: boolean;
+  // totalposts: number;
+}) {
   const [selectedCategory, setSelectedCategory] = useState<string>(category); //기본 카테고리
-  const [communities, setCommunities] = useState<CommunitiesProps[]>(communityList.posts); //초기 데이터
-  
+  const [communities, setCommunities] = useState<CommunitiesProps[]>(
+    communityList.posts
+  ); //초기 데이터
+
   //무한스크롤 추가
   const [currentPage, setCurrentPage] = useState<number>(Number(page) || 0);
   const [hasMore, setHasMore] = useState<boolean>(communityList.hasMore);
-  const {ref, inView} = useInView({
+  const { ref, inView } = useInView({
     threshold: 0.5, // 요소가 50% 보일 때 inView가 true로 바뀜
   });
+  const [status, setStatus] = useState<Status>("idle");
 
   const router = useRouter();
 
   //카테고리 변경시 URL 업데이트
   useEffect(() => {
     //카테고리 변경시 데이터 가져옴
-    const fetchData = async() => {
-      const data: communityResponseDetailProps = await getCommunities(selectedCategory, page);
-      setCommunities(data.posts);
-      setHasMore(data.hasMore);
-      setCurrentPage(0);
+    const fetchData = async () => {
+      setStatus("loading");
+
+      try {
+        const data: communityResponseDetailProps = await getCommunities(
+          selectedCategory,
+          "0" //카테고리 변경시 무조건 0페이지부터
+        );
+        setCommunities(data.posts);
+        setHasMore(data.hasMore);
+        setCurrentPage(0);
+        setStatus("success");
+      } catch (error) {
+        console.error(error);
+        setStatus("error");
+      }
     };
 
     fetchData();
-    router.push(`/community/posts/list?category=${selectedCategory}&page=${page}`); //여기서 page=0이 되어야 일치
-  },[selectedCategory, page]);
+    router.push(
+      // `/community/posts/list?category=${selectedCategory}&page=${page}`
+      `/community/posts/list?category=${selectedCategory}&page=0` //카테고리
+    ); //여기서 page=0이 되어야 일치
+  }, [selectedCategory, page]);
 
+  //무한스크롤 + 요청 상태 추가
+  useEffect(() => {
+    if (inView && hasMore) {
+      const fetchMoreData = async () => {
+        setStatus("loading");
 
-  //무한스크롤
-  useEffect(()=> {
-    if(inView && hasMore) {
-      const fetchMoreData = async() => {
-        const nextPage = currentPage + 1;
-        const data: communityResponseDetailProps = await getCommunities(selectedCategory, String(nextPage));
-
-        if(data.posts.length > 0) {
-          setCommunities((prev) => [...prev, ...data.posts]);
-          setHasMore(data.hasMore);
-          setCurrentPage(nextPage);
-        }else{
-          setHasMore(false);
+        try {
+          const nextPage = currentPage + 1;
+          const data: communityResponseDetailProps = await getCommunities(
+            selectedCategory,
+            String(nextPage)
+          );
+          if (data.posts.length > 0) {
+            setCommunities((prev) => [...prev, ...data.posts]);
+            setHasMore(data.hasMore);
+            setCurrentPage(nextPage);
+            setStatus("success");
+          } else {
+            setHasMore(false);
+          }
+        } catch (error) {
+          console.error(error);
+          setStatus("error");
         }
       };
 
       fetchMoreData();
     }
-  },[inView, hasMore, currentPage, selectedCategory]);
+  }, [inView, hasMore, currentPage, selectedCategory]);
 
   return (
     <div>
@@ -93,33 +129,40 @@ export default function CommunitiesClient({ communityList, category, page }:{
         ))}
       </div>
 
-        {/*로딩 중*/}
-        {/* {loading? (
+      {/*로딩 중*/}
+      {/* {loading? (
           <p>로딩 중...</p>
         ) : ( */}
-          <ul className="flex flex-col gap-1 px-4 pb-10">
-          {communities && communities.length > 0 ? (
-            communities.map((community) => (
-              <CategoryFilter key={community.postId} community={community} selectedCategory={selectedCategory} />
-            ))
-          ) : (
-            // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
-            <p className="text-gray-500"></p>
-          )}
-        </ul>
-        {/* )} */}
-        <FloatingButton />
-
-        {/* 무한스크롤 감지 */}
-        {hasMore? (
-          <div className="flex justify-center pb-8 gap-2">
-            <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
-            <div ref={ref} className="text-gray-400">Loading more...</div>
-          </div>
-
+      <ul className="flex flex-col gap-1 px-4 pb-10">
+        {communities && communities.length > 0 ? (
+          communities.map((community) => (
+            <CategoryFilter
+              key={community.postId}
+              community={community}
+              selectedCategory={selectedCategory}
+            />
+          ))
         ) : (
-          <p className="text-center text-gray-400 pb-8">더 이상 게시물이 없습니다.</p>
+          // <p className="text-gray-500">해당 커뮤니티가 존재하지 않습니다.</p>
+          <p className="text-gray-500"></p>
         )}
+      </ul>
+      {/* )} */}
+      <FloatingButton />
+
+      {/* 무한스크롤 감지 */}
+      {hasMore ? (
+        <div className="flex justify-center pb-8 gap-2">
+          <div className="w-6 h-6 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
+          <div ref={ref} className="text-gray-400">
+            Loading more...
+          </div>
+        </div>
+      ) : (
+        <p className="text-center text-gray-400 pb-8">
+          더 이상 게시물이 없습니다.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/community/posts/list/clientPage.tsx
+++ b/src/app/community/posts/list/clientPage.tsx
@@ -49,7 +49,7 @@ export default function CommunitiesClient({
     threshold: 0.5, // 요소가 50% 보일 때 inView가 true로 바뀜
   });
   const [status, setStatus] = useState<Status>("idle"); //요청 상태
-  const [isFetchingMore, setIsFetchingMore] = useState<boolean>(false); //로딩스피너
+  const [isFetchingMore, setIsFetchingMore] = useState<boolean>(false); //무한스크롤 중복요청 방지
 
   const router = useRouter();
 
@@ -79,7 +79,7 @@ export default function CommunitiesClient({
       // `/community/posts/list?category=${selectedCategory}&page=${page}`
       `/community/posts/list?category=${selectedCategory}&page=0` //카테고리
     ); //여기서 page=0이 되어야 일치
-  }, [selectedCategory, page]);
+  }, [selectedCategory]);
 
   //무한스크롤 + 요청 상태 추가
   useEffect(() => {


### PR DESCRIPTION
**Fix: 커뮤니티 목록 무한스크롤 로딩 상태 및 중복 요청 처리 개선**
-
### [목적]
- 커뮤니티 게시판 무한스크롤 동작을 안정적으로 만들기 위한 수정
  - 요청 상태를 4단계로 나누어 관리
  - inView 감지 시 API 요청이 여러 번 발생하는 문제 방지
 
</br>

### [작업 내용]
1. **요청 상태 4단계 타입 추가 (`status`)**
   - `"idle" | "loading" | "success" | "error"` 로 상태 정의
     - `idle`: 요청 전 초기 상태
     - `loading`: 서버에 요청을 보내고 응답을 기다리는 중
     - `success`: 응답을 정상적으로 받은 상태
     - `error`: 요청 실패 상태
   - 위 네 가지 상태로 요청 흐름을 명확하게 관리

2. **무한스크롤 중복 요청 방지를 위한 `isFetchingMore` 플래그 추가**
   - 관련 `useEffect`에서 아래와 같이 가드 조건 추가
     ```ts
     if (!inView || !hasMore || isFetchingMore) return;
     ```
     → 같은 페이지에 대한 중복 요청이 발생하지 않도록 방지
   - 하단 “Loading more...” 로딩 스피너는 `isFetchingMore` 기준으로 노출/숨김 처리

3. **카테고리 변경 시 의존성 배열 정리**
   - 카테고리 변경 시에는 항상 0페이지부터 다시 불러오기 때문에,
     해당 `useEffect`의 의존성 배열에서 `page` 제거
   - `useEffect`가 `selectedCategory` 변경에만 반응하도록 개선하여
     불필요한 재요청 방지